### PR TITLE
igb - Implement MAC filtering

### DIFF
--- a/hw/net/igb_pf_core.h
+++ b/hw/net/igb_pf_core.h
@@ -106,4 +106,10 @@ igb_pf_can_receive(IgbPfCore *core);
 
 void
 igb_pf_core_set_link_status(IgbPfCore *core, bool link_down);
+
+bool
+igb_pf_promisc(IgbPfCore *core);
+
+void
+igb_pf_mac_check(IgbPfCore *core, const uint8_t mac_dst[], uint32_t *bitmap);
 #endif

--- a/hw/net/igb_pf_reg_constants.h
+++ b/hw/net/igb_pf_reg_constants.h
@@ -231,6 +231,7 @@
 
 /* Receive Control */
 #define IGB_RCTL_EN             0x00000002    /* enable */
+#define IGB_RCTL_UPE            BIT(3)       /* Unicast Promiscuous */
 #define IGB_RCTL_SZ_2048        0x00000000    /* rx buffer size 1024 */
 #define IGB_RCTL_SZ_1024        0x00010000    /* rx buffer size 1024 */
 #define IGB_RCTL_SZ_512         0x00020000    /* rx buffer size 512 */
@@ -293,6 +294,8 @@
  * manageability enabled, allowing us room for 15 multicast addresses.
  */
 #define IGB_RAH_AV  0x80000000        /* Receive descriptor valid */
+#define IGB_RAH_ASEL_EXTRACT(v)  (((v)>>16) &  0x3 )
+#define IGB_RAH_POOL_EXTRACT(v)  (((v)>>18) & 0xff )
 
 /* PHY Control Register */
 #define MII_CR_SPEED_SELECT_MSB 0x0040 /* bits 6,13: 10=1000, 01=100, 00=10 */


### PR DESCRIPTION
Extend IGB driver with a crude form of MAC filtering/switching so that SR-IOV
VFs can communicate with each other without seeing all packets.

This allows normal communication with VFs QEMU user-mode networking as the
QEMU-side of the user-mode networking seems to see all packets and send TCP
RSTs blindly without considering the destination IP.